### PR TITLE
Migrate to RxJava 3

### DIFF
--- a/app/src/main/java/com/alvindizon/tampisaw/core/ui/BaseViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/core/ui/BaseViewModel.kt
@@ -3,7 +3,7 @@ package com.alvindizon.tampisaw.core.ui
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
-import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 
 abstract class BaseViewModel  constructor(
     protected var compositeDisposable: CompositeDisposable = CompositeDisposable()

--- a/app/src/main/java/com/alvindizon/tampisaw/data/UnsplashRepoImpl.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/UnsplashRepoImpl.kt
@@ -4,7 +4,7 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import androidx.paging.rxjava2.observable
+import androidx.paging.rxjava3.observable
 import com.alvindizon.tampisaw.core.Const
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import com.alvindizon.tampisaw.data.networking.model.getcollections.GetCollectionsResponse
@@ -15,13 +15,13 @@ import com.alvindizon.tampisaw.data.paging.SearchCollectionsPagingSource
 import com.alvindizon.tampisaw.data.paging.SearchPhotosPagingSource
 import com.alvindizon.tampisaw.data.paging.UnsplashPagingSource
 import com.alvindizon.tampisaw.domain.UnsplashRepo
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
 @ExperimentalPagingApi
-class UnsplashRepoImpl(private val unsplashApi: UnsplashApi): UnsplashRepo {
+class UnsplashRepoImpl(private val unsplashApi: UnsplashApi) : UnsplashRepo {
 
     override fun getAllPhotos(): Observable<PagingData<ListPhotosResponse>> = Pager(
         config = PagingConfig(Const.PAGE_SIZE),
@@ -30,7 +30,12 @@ class UnsplashRepoImpl(private val unsplashApi: UnsplashApi): UnsplashRepo {
         // IllegalStateException when adapter.refresh() is called--
         // Exception message states that the same PagingSource was used as the prev request,
         // and a new PagingSource is required
-        pagingSourceFactory = { UnsplashPagingSource(unsplashApi, UnsplashPagingSource.GetPhotosType.Gallery) }
+        pagingSourceFactory = {
+            UnsplashPagingSource(
+                unsplashApi,
+                UnsplashPagingSource.GetPhotosType.Gallery
+            )
+        }
     ).observable
 
     override fun getPhoto(id: String): Single<GetPhotoResponse> = unsplashApi.getPhoto(id)
@@ -41,21 +46,29 @@ class UnsplashRepoImpl(private val unsplashApi: UnsplashApi): UnsplashRepo {
         pagingSourceFactory = { CollectionPagingSource(unsplashApi) }
     ).observable
 
-    override fun getCollectionPhotos(id: String): Observable<PagingData<ListPhotosResponse>> = Pager(
-        config = PagingConfig(Const.PAGE_SIZE),
-        remoteMediator = null,
-        pagingSourceFactory = { UnsplashPagingSource(unsplashApi, UnsplashPagingSource.GetPhotosType.Collection, id) }
-    ).observable
+    override fun getCollectionPhotos(id: String): Observable<PagingData<ListPhotosResponse>> =
+        Pager(
+            config = PagingConfig(Const.PAGE_SIZE),
+            remoteMediator = null,
+            pagingSourceFactory = {
+                UnsplashPagingSource(
+                    unsplashApi,
+                    UnsplashPagingSource.GetPhotosType.Collection,
+                    id
+                )
+            }
+        ).observable
 
     override fun searchPhotos(query: String): Observable<PagingData<ListPhotosResponse>> = Pager(
-            config = PagingConfig(Const.PAGE_SIZE),
-            remoteMediator = null,
-            pagingSourceFactory = { SearchPhotosPagingSource(unsplashApi, query)}
+        config = PagingConfig(Const.PAGE_SIZE),
+        remoteMediator = null,
+        pagingSourceFactory = { SearchPhotosPagingSource(unsplashApi, query) }
     ).observable
 
-    override fun searchCollections(query: String): Observable<PagingData<GetCollectionsResponse>> = Pager(
+    override fun searchCollections(query: String): Observable<PagingData<GetCollectionsResponse>> =
+        Pager(
             config = PagingConfig(Const.PAGE_SIZE),
             remoteMediator = null,
-            pagingSourceFactory = { SearchCollectionsPagingSource(unsplashApi, query)}
-    ).observable
+            pagingSourceFactory = { SearchCollectionsPagingSource(unsplashApi, query) }
+        ).observable
 }

--- a/app/src/main/java/com/alvindizon/tampisaw/data/download/ImageDownloader.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/download/ImageDownloader.kt
@@ -15,10 +15,10 @@ import androidx.lifecycle.LiveData
 import androidx.work.Data
 import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.RxWorker
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.rxjava3.RxWorker
 import androidx.work.workDataOf
 import com.alvindizon.tampisaw.core.ui.NotifsHelper
 import com.alvindizon.tampisaw.core.utils.FILE_PROVIDER_AUTHORITY
@@ -27,7 +27,7 @@ import com.alvindizon.tampisaw.core.utils.TAMPISAW_RELATIVE_PATH
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 import okhttp3.ResponseBody
 import okio.BufferedSink
 import okio.buffer

--- a/app/src/main/java/com/alvindizon/tampisaw/data/file/FileManager.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/file/FileManager.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.net.Uri
 import com.alvindizon.tampisaw.core.utils.getUriForPhoto
 import com.alvindizon.tampisaw.data.wallpaper.DownloadPhotoException
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 interface FileManager {

--- a/app/src/main/java/com/alvindizon/tampisaw/data/networking/api/UnsplashApi.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/networking/api/UnsplashApi.kt
@@ -5,8 +5,8 @@ import com.alvindizon.tampisaw.data.networking.model.getphoto.GetPhotoResponse
 import com.alvindizon.tampisaw.data.networking.model.listphotos.ListPhotosResponse
 import com.alvindizon.tampisaw.data.networking.model.search.SearchCollectionsResponse
 import com.alvindizon.tampisaw.data.networking.model.search.SearchPhotosResponse
-import io.reactivex.Completable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Single
 import okhttp3.ResponseBody
 import retrofit2.http.GET
 import retrofit2.http.Path

--- a/app/src/main/java/com/alvindizon/tampisaw/data/paging/CollectionPagingSource.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/paging/CollectionPagingSource.kt
@@ -1,12 +1,12 @@
 package com.alvindizon.tampisaw.data.paging
 
 import androidx.paging.PagingState
-import androidx.paging.rxjava2.RxPagingSource
+import androidx.paging.rxjava3.RxPagingSource
 import com.alvindizon.tampisaw.core.Const
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import com.alvindizon.tampisaw.data.networking.model.getcollections.GetCollectionsResponse
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 // TODO think of a way to make a generic paging source
 class CollectionPagingSource(private val unsplashApi: UnsplashApi) :

--- a/app/src/main/java/com/alvindizon/tampisaw/data/paging/SearchCollectionsPagingSource.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/paging/SearchCollectionsPagingSource.kt
@@ -1,12 +1,12 @@
 package com.alvindizon.tampisaw.data.paging
 
 import androidx.paging.PagingState
-import androidx.paging.rxjava2.RxPagingSource
+import androidx.paging.rxjava3.RxPagingSource
 import com.alvindizon.tampisaw.core.Const
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import com.alvindizon.tampisaw.data.networking.model.getcollections.GetCollectionsResponse
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 class SearchCollectionsPagingSource(
     private val unsplashApi: UnsplashApi,

--- a/app/src/main/java/com/alvindizon/tampisaw/data/paging/SearchPhotosPagingSource.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/paging/SearchPhotosPagingSource.kt
@@ -1,12 +1,12 @@
 package com.alvindizon.tampisaw.data.paging
 
 import androidx.paging.PagingState
-import androidx.paging.rxjava2.RxPagingSource
+import androidx.paging.rxjava3.RxPagingSource
 import com.alvindizon.tampisaw.core.Const
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import com.alvindizon.tampisaw.data.networking.model.listphotos.ListPhotosResponse
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 class SearchPhotosPagingSource(private val unsplashApi: UnsplashApi, private val query: String) :
     RxPagingSource<Int, ListPhotosResponse>() {

--- a/app/src/main/java/com/alvindizon/tampisaw/data/paging/UnsplashPagingSource.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/paging/UnsplashPagingSource.kt
@@ -1,12 +1,12 @@
 package com.alvindizon.tampisaw.data.paging
 
 import androidx.paging.PagingState
-import androidx.paging.rxjava2.RxPagingSource
+import androidx.paging.rxjava3.RxPagingSource
 import com.alvindizon.tampisaw.core.Const
 import com.alvindizon.tampisaw.data.networking.api.UnsplashApi
 import com.alvindizon.tampisaw.data.networking.model.listphotos.ListPhotosResponse
-import io.reactivex.Single
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 class UnsplashPagingSource(
     private val unsplashApi: UnsplashApi,

--- a/app/src/main/java/com/alvindizon/tampisaw/data/wallpaper/WallpaperSettingManager.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/data/wallpaper/WallpaperSettingManager.kt
@@ -12,8 +12,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveDataReactiveStreams
 import androidx.work.WorkInfo
 import com.alvindizon.tampisaw.data.download.ImageDownloader
-import io.reactivex.Completable
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Observable
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.util.*

--- a/app/src/main/java/com/alvindizon/tampisaw/di/app/NetworkModule.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/di/app/NetworkModule.kt
@@ -12,7 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
@@ -51,7 +51,7 @@ class NetworkModule {
     fun provideRetrofit(okHttpClient: OkHttpClient, moshi: Moshi): Retrofit = Retrofit.Builder()
         .baseUrl(API_URL)
         .addConverterFactory(MoshiConverterFactory.create(moshi))
-        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
         .client(okHttpClient)
         .build()
 

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/DownloadPhotoUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/DownloadPhotoUseCase.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
 import com.alvindizon.tampisaw.data.file.FileManager
 import com.alvindizon.tampisaw.data.wallpaper.WallpaperSettingManager
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class DownloadPhotoUseCase @Inject constructor(

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/GetAllCollectionsUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/GetAllCollectionsUseCase.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.alvindizon.tampisaw.core.toUnsplashCollection
 import com.alvindizon.tampisaw.features.collections.UnsplashCollection
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import javax.inject.Inject
 
 class GetAllCollectionsUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/GetAllPhotosUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/GetAllPhotosUseCase.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.alvindizon.tampisaw.core.toUnsplashPhoto
 import com.alvindizon.tampisaw.features.gallery.UnsplashPhoto
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import javax.inject.Inject
 
 class GetAllPhotosUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/GetCollectionPhotosUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/GetCollectionPhotosUseCase.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.alvindizon.tampisaw.core.toUnsplashPhoto
 import com.alvindizon.tampisaw.features.gallery.UnsplashPhoto
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import javax.inject.Inject
 
 class GetCollectionPhotosUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/GetPhotoUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/GetPhotoUseCase.kt
@@ -1,7 +1,7 @@
 package com.alvindizon.tampisaw.domain
 
 import com.alvindizon.tampisaw.data.networking.model.getphoto.GetPhotoResponse
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class GetPhotoUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/SearchCollectionsUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/SearchCollectionsUseCase.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.alvindizon.tampisaw.core.toUnsplashCollection
 import com.alvindizon.tampisaw.features.collections.UnsplashCollection
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import javax.inject.Inject
 
 class SearchCollectionsUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/SearchPhotosUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/SearchPhotosUseCase.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.alvindizon.tampisaw.core.toUnsplashPhoto
 import com.alvindizon.tampisaw.features.gallery.UnsplashPhoto
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import javax.inject.Inject
 
 class SearchPhotosUseCase @Inject constructor(private val unsplashRepo: UnsplashRepo) {

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/SetWallpaperByBitmapUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/SetWallpaperByBitmapUseCase.kt
@@ -2,7 +2,7 @@ package com.alvindizon.tampisaw.domain
 
 import android.net.Uri
 import com.alvindizon.tampisaw.data.wallpaper.WallpaperSettingManager
-import io.reactivex.Completable
+import io.reactivex.rxjava3.core.Completable
 import javax.inject.Inject
 
 class SetWallpaperByBitmapUseCase @Inject constructor(

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/SetWallpaperUseCase.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/SetWallpaperUseCase.kt
@@ -3,7 +3,7 @@ package com.alvindizon.tampisaw.domain
 import android.app.Activity
 import android.net.Uri
 import com.alvindizon.tampisaw.data.wallpaper.WallpaperSettingManager
-import io.reactivex.Completable
+import io.reactivex.rxjava3.core.Completable
 import javax.inject.Inject
 
 class SetWallpaperUseCase @Inject constructor(

--- a/app/src/main/java/com/alvindizon/tampisaw/domain/UnsplashRepo.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/domain/UnsplashRepo.kt
@@ -4,8 +4,8 @@ import androidx.paging.PagingData
 import com.alvindizon.tampisaw.data.networking.model.getcollections.GetCollectionsResponse
 import com.alvindizon.tampisaw.data.networking.model.getphoto.GetPhotoResponse
 import com.alvindizon.tampisaw.data.networking.model.listphotos.ListPhotosResponse
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 
 interface UnsplashRepo {
 

--- a/app/src/main/java/com/alvindizon/tampisaw/features/collections/CollectionListViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/features/collections/CollectionListViewModel.kt
@@ -4,14 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.rxjava2.cachedIn
+import androidx.paging.rxjava3.cachedIn
 import com.alvindizon.tampisaw.core.ui.BaseViewModel
 import com.alvindizon.tampisaw.domain.GetAllCollectionsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.kotlin.subscribeBy
+import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 

--- a/app/src/main/java/com/alvindizon/tampisaw/features/collections/CollectionViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/features/collections/CollectionViewModel.kt
@@ -4,15 +4,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.rxjava2.cachedIn
+import androidx.paging.rxjava3.cachedIn
 import com.alvindizon.tampisaw.core.ui.BaseViewModel
 import com.alvindizon.tampisaw.domain.GetCollectionPhotosUseCase
 import com.alvindizon.tampisaw.features.gallery.UnsplashPhoto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.kotlin.subscribeBy
+import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 

--- a/app/src/main/java/com/alvindizon/tampisaw/features/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/features/details/DetailsViewModel.kt
@@ -13,11 +13,11 @@ import com.alvindizon.tampisaw.domain.GetPhotoUseCase
 import com.alvindizon.tampisaw.domain.SetWallpaperByBitmapUseCase
 import com.alvindizon.tampisaw.domain.SetWallpaperUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.Completable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.kotlin.subscribeBy
+import io.reactivex.rxjava3.schedulers.Schedulers
 import javax.inject.Inject
 
 @HiltViewModel

--- a/app/src/main/java/com/alvindizon/tampisaw/features/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/features/gallery/GalleryViewModel.kt
@@ -4,14 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.rxjava2.cachedIn
+import androidx.paging.rxjava3.cachedIn
 import com.alvindizon.tampisaw.core.ui.BaseViewModel
 import com.alvindizon.tampisaw.domain.GetAllPhotosUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.kotlin.subscribeBy
+import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 

--- a/app/src/main/java/com/alvindizon/tampisaw/features/search/SearchViewModel.kt
+++ b/app/src/main/java/com/alvindizon/tampisaw/features/search/SearchViewModel.kt
@@ -4,17 +4,17 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.rxjava2.cachedIn
+import androidx.paging.rxjava3.cachedIn
 import com.alvindizon.tampisaw.core.ui.BaseViewModel
 import com.alvindizon.tampisaw.domain.SearchCollectionsUseCase
 import com.alvindizon.tampisaw.domain.SearchPhotosUseCase
 import com.alvindizon.tampisaw.features.collections.UnsplashCollection
 import com.alvindizon.tampisaw.features.gallery.UnsplashPhoto
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.rxkotlin.plusAssign
-import io.reactivex.rxkotlin.subscribeBy
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.kotlin.plusAssign
+import io.reactivex.rxjava3.kotlin.subscribeBy
+import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 

--- a/app/src/test/java/com/alvindizon/tampisaw/RxSchedulerExtension.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/RxSchedulerExtension.kt
@@ -1,8 +1,8 @@
 package com.alvindizon.tampisaw
 
-import io.reactivex.android.plugins.RxAndroidPlugins
-import io.reactivex.plugins.RxJavaPlugins
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
+import io.reactivex.rxjava3.schedulers.Schedulers
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
 import org.junit.jupiter.api.extension.ExtensionContext

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/DownloadPhotoUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/DownloadPhotoUseCaseTest.kt
@@ -8,8 +8,8 @@ import com.alvindizon.tampisaw.data.file.FileManager
 import com.alvindizon.tampisaw.data.wallpaper.WallpaperSettingManager
 import io.mockk.every
 import io.mockk.mockk
-import io.reactivex.Completable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Single
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/GetAllCollectionsUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/GetAllCollectionsUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.alvindizon.tampisaw.TestConstants
 import com.alvindizon.tampisaw.collectData
 import io.mockk.every
 import io.mockk.mockk
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/GetAllPhotosUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/GetAllPhotosUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.alvindizon.tampisaw.TestConstants
 import com.alvindizon.tampisaw.collectData
 import io.mockk.every
 import io.mockk.mockk
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/GetCollectionPhotosUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/GetCollectionPhotosUseCaseTest.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/SearchCollectionsUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/SearchCollectionsUseCaseTest.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/domain/SearchPhotosUseCaseTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/domain/SearchPhotosUseCaseTest.kt
@@ -6,7 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/features/collections/CollectionListViewModelTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/features/collections/CollectionListViewModelTest.kt
@@ -10,7 +10,7 @@ import com.alvindizon.tampisaw.testObserver
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/features/collections/CollectionViewModelTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/features/collections/CollectionViewModelTest.kt
@@ -5,7 +5,7 @@ import com.alvindizon.tampisaw.domain.GetCollectionPhotosUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/features/details/DetailsViewModelTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/features/details/DetailsViewModelTest.kt
@@ -23,8 +23,8 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import io.reactivex.Completable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.BeforeEach

--- a/app/src/test/java/com/alvindizon/tampisaw/features/gallery/GalleryViewModelTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/features/gallery/GalleryViewModelTest.kt
@@ -5,7 +5,7 @@ import com.alvindizon.tampisaw.domain.GetAllPhotosUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/alvindizon/tampisaw/features/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/alvindizon/tampisaw/features/search/SearchViewModelTest.kt
@@ -7,7 +7,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,27 +12,25 @@ object Libs {
         "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.lifecycle}",
         "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.lifecycle}",
         "androidx.lifecycle:lifecycle-common-java8:${Versions.lifecycle}",
-        "androidx.room:room-runtime:${Versions.room}",
-        "androidx.room:room-rxjava2:${Versions.room}",
-        "io.reactivex.rxjava2:rxandroid:${Versions.rxAndroid}",
-        "io.reactivex.rxjava2:rxjava:${Versions.rxJava}",
-        "io.reactivex.rxjava2:rxkotlin:${Versions.rxKotlin}",
+        "io.reactivex.rxjava3:rxandroid:${Versions.rxAndroid}",
+        "io.reactivex.rxjava3:rxjava:${Versions.rxJava}",
+        "io.reactivex.rxjava3:rxkotlin:${Versions.rxKotlin}",
         "com.google.code.findbugs:jsr305:${Versions.findBugs}",
         "com.squareup.retrofit2:retrofit:${Versions.retrofit}",
-        "com.squareup.retrofit2:adapter-rxjava2:${Versions.retrofit}",
+        "com.squareup.retrofit2:adapter-rxjava3:${Versions.retrofit}",
         "com.squareup.retrofit2:converter-moshi:${Versions.retrofit}",
         "com.squareup.moshi:moshi:${Versions.moshi}",
         "com.squareup.okhttp3:logging-interceptor:${Versions.okHttpLogInterceptor}",
         "com.github.skydoves:androidveil:${Versions.androidVeil}",
         "com.github.bumptech.glide:glide:${Versions.glide}",
         "androidx.paging:paging-runtime:${Versions.paging}",
-        "androidx.paging:paging-rxjava2:${Versions.paging}",
+        "androidx.paging:paging-rxjava3:${Versions.paging}",
         "androidx.preference:preference:${Versions.preference}",
         "androidx.navigation:navigation-fragment-ktx:${Versions.navigation}",
         "androidx.navigation:navigation-ui-ktx:${Versions.navigation}",
         "com.nambimobile.widgets:expandable-fab:${Versions.fab}",
         "androidx.work:work-runtime-ktx:${Versions.work}",
-        "androidx.work:work-rxjava2:${Versions.work}",
+        "androidx.work:work-rxjava3:${Versions.work}",
         "com.squareup.okio:okio:${Versions.okio}",
         "androidx.swiperefreshlayout:swiperefreshlayout:${Versions.swiperefreshlayout}",
         "com.google.dagger:hilt-android:${Versions.hilt}",
@@ -57,7 +55,6 @@ object Libs {
 
     val kaptLibs = listOf(
         "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}",
-        "androidx.room:room-compiler:${Versions.room}",
         "com.google.dagger:hilt-android-compiler:${Versions.hilt}",
         "androidx.hilt:hilt-compiler:${Versions.hiltAndroidX}"
     )
@@ -80,10 +77,9 @@ object Versions {
     const val paging = "3.0.0"
     const val retrofit = "2.9.0"
     const val testExtJunit = "1.1.2"
-    const val rxJava = "2.2.21"
+    const val rxJava = "3.1.2"
     const val moshi = "1.12.0"
     const val material = "1.2.1"
-    const val room = "2.3.0"
     const val findBugs = "3.0.2"
     const val okHttpLogInterceptor = "4.9.1"
     const val androidVeil = "1.1.1"
@@ -94,8 +90,8 @@ object Versions {
     const val swiperefreshlayout = "1.1.0"
     const val coreTesting = "2.1.0"
     const val coroutine = "1.5.0"
-    const val rxAndroid = "2.1.1"
-    const val rxKotlin = "2.4.0"
+    const val rxAndroid = "3.0.0"
+    const val rxKotlin = "3.0.1"
     const val gradleVersions = "0.36.0"
     const val mockk = "1.11.0"
     const val junit5 = "5.7.2"


### PR DESCRIPTION
- Remove Room
- Replace RxJava2-dependent libraries to RxJava 3 ones 
Signed-off-by: Alvin Dizon <alvin.dizon91@gmail.com>