### PR TITLE
Fix navigating from search collection results to collection

### DIFF
--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -6,7 +6,7 @@
         android:title="@string/home"/>
 
     <item
-        android:id="@id/collections_nav_graph"
+        android:id="@id/collections_list_nav_graph"
         android:icon="@drawable/ic_collections"
         android:title="@string/collections"/>
 

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -7,6 +7,8 @@
 
     <include app:graph="@navigation/details_nav_graph" />
 
+    <include app:graph="@navigation/collections_list_nav_graph" />
+
     <include app:graph="@navigation/collections_nav_graph" />
 
     <include app:graph="@navigation/search_nav_graph" />

--- a/feature/collections/src/main/java/com/alvindizon/tampisaw/collections/ui/CollectionListFragment.kt
+++ b/feature/collections/src/main/java/com/alvindizon/tampisaw/collections/ui/CollectionListFragment.kt
@@ -42,13 +42,15 @@ class CollectionListFragment : Fragment(R.layout.fragment_collection_list) {
         val adapter = CollectionAdapter { collection, itemBinding ->
             val extras = getNavigatorExtras(itemBinding.collectionTitle)
             findNavController().navigate(
-                CollectionListFragmentDirections.collectionAction(
+                R.id.collections_nav_graph,
+                CollectionFragmentArgs(
                     collection.id,
                     collection.description,
                     collection.totalPhotos,
                     collection.fullname,
                     collection.title
-                ),
+                ).toBundle(),
+                null,
                 extras
             )
         }

--- a/feature/collections/src/main/res/navigation/collections_list_nav_graph.xml
+++ b/feature/collections/src/main/res/navigation/collections_list_nav_graph.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:startDestination="@id/collection_list_dest"
+    android:id="@+id/collections_list_nav_graph">
+
+    <fragment
+        android:id="@+id/collection_list_dest"
+        android:name="com.alvindizon.tampisaw.collections.ui.CollectionListFragment"
+        android:label="fragment_collection_list">
+
+        <action
+            android:id="@+id/navigateToCollection"
+            app:destination="@id/collection_dest"/>
+    </fragment>
+
+</navigation>

--- a/feature/collections/src/main/res/navigation/collections_nav_graph.xml
+++ b/feature/collections/src/main/res/navigation/collections_nav_graph.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    app:startDestination="@id/collection_list_dest"
+    app:startDestination="@id/collection_dest"
     android:id="@+id/collections_nav_graph">
-
-    <fragment
-        android:id="@+id/collection_list_dest"
-        android:name="com.alvindizon.tampisaw.collections.ui.CollectionListFragment"
-        android:label="fragment_collection_list">
-
-        <action
-            android:id="@+id/collectionAction"
-            app:destination="@id/collection_dest" />
-    </fragment>
 
     <fragment
         android:id="@+id/collection_dest"


### PR DESCRIPTION
- In order to accomodate transitions (Navigator.Extras), it was necessary to create a separate nav graph that contains the collection fragment. Previously, in order to navigate to the collection from search results, it would involve inflating the existing collection nav graph and specifiying that the start destination would be the collection fragment.

- refs: https://www.valueof.io/blog/jetpack-navigation-cross-navgraph-destinations